### PR TITLE
Adding fields timestamp and service

### DIFF
--- a/log.go
+++ b/log.go
@@ -2,11 +2,45 @@ package wrapplog
 
 import (
 	"os"
+	"path"
 
 	"github.com/Sirupsen/logrus"
 )
 
+type WrappHook struct {
+	ServiceName string
+}
+
+func (w *WrappHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (w *WrappHook) Fire(entry *logrus.Entry) error {
+	entry.Data["service"] = w.ServiceName
+
+	return nil
+}
+
 func init() {
-	logrus.SetFormatter(&logrus.JSONFormatter{})
+	serviceName := os.Getenv("SERVICE_NAME")
+	if serviceName == "" {
+		// Fallback to executable name when
+		// service name isn't specified
+		exePath, err := os.Executable()
+		if err != nil {
+			serviceName = "unknown"
+		} else {
+			serviceName = path.Base(exePath)
+		}
+	}
+
+	logrus.AddHook(&WrappHook{ServiceName: serviceName})
+	logrus.SetFormatter(&logrus.JSONFormatter{
+		FieldMap: logrus.FieldMap{
+			logrus.FieldKeyLevel: "level",
+			logrus.FieldKeyMsg:   "msg",
+			logrus.FieldKeyTime:  "timestamp",
+		},
+	})
 	logrus.SetOutput(os.Stdout)
 }


### PR DESCRIPTION
Timestamp and service fields weren't added by default in this library. This PR address this issue changing time field name and adding service name, based on an environment variable or executable name